### PR TITLE
fix: sửa critical bugs, race condition và rate limiting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Run all tests
+pytest tests/ -v
+
+# Run a specific test file
+pytest tests/test_database_service.py -v
+pytest tests/test_risk_manager.py -v
+
+# Stop on first failure
+pytest tests/ -v -x
+
+# Lint (CI threshold: score >= 5, warnings/refactors disabled)
+pylint $(git ls-files '*.py') --disable=C,R --fail-under=5
+
+# Run the bot (fake-money demo, no API keys needed)
+python -m bots.demo_fake_bot --symbol BTC/USDT --exchanges binance okx bybit --duration 5
+
+# Run the bot via main entry point
+python main.py fake-money <renew_minutes> <usdt_amount> <exchange1> <exchange2> <exchange3> [symbol]
+python main.py fake-money 15 1000 binance kucoin okx BTC/USDT --dry-run
+
+# Multi-pair mode
+python main.py fake-money 15 1000 binance kucoin okx --symbols BTC/USDT ETH/USDT SOL/USDT
+
+# Web dashboard
+python -m uvicorn web.app:app --reload --port 8000
+```
+
+## Architecture
+
+### Request flow
+
+`main.py` parses CLI args → instantiates all services → creates the appropriate bot → calls `bot.configure()` then `bot.start()` in an async loop that repeats each `renew_time` minute session until interrupted.
+
+On Windows, `aiohttp.ThreadedResolver` is forced at startup to avoid `aiodns` DNS errors.
+
+### Bot hierarchy
+
+```
+BaseBot (bots/base_bot.py)
+├── ClassicBot        — buy lowest-ask exchange, sell highest-bid exchange
+├── DeltaNeutralBot   — spot arbitrage + short futures hedge on kucoinfutures
+└── FakeMoneyBot      — full simulation with no real orders
+```
+
+`BaseBot._start_orderbook_loop()` fans out one `asyncio` task per exchange using `ccxt.pro.watch_order_book`. Each tick calls `process_orderbook()` which detects spread, checks `RiskManager`, then calls `_execute_trade()`. Real orders are placed via `AsyncOrderService.place_arbitrage_orders()` which fires buy and sell simultaneously with `asyncio.gather`.
+
+`MultiPairManager` (services/multi_pair_manager.py) runs one bot instance per symbol in parallel for multi-pair mode.
+
+### Services
+
+| Service | Responsibility |
+|---|---|
+| `ExchangeService` | Wraps ccxt/ccxt.pro; reads API keys from env; token-bucket rate limiting per exchange; optional sandbox mode via `USE_SANDBOX=true` |
+| `BalanceService` | Reads/writes `balance.txt` and `start_balance.txt`; emergency USDT conversion on Ctrl+C |
+| `AsyncOrderService` | Concurrent limit/market order placement and fill-polling; returns slippage data |
+| `OrderService` | Synchronous order placement fallback |
+| `DatabaseService` | SQLite (WAL mode) at `data/arbitrage.db`; tables: sessions, trades, opportunities, balances |
+| `RiskManager` | Pre/post-trade guards: max drawdown, per-trade loss, consecutive losses, slippage, cooldown |
+| `NotificationService` | Telegram alerts; enabled by `ENABLE_TELEGRAM=true` |
+| `SessionRecovery` | Detects `status='interrupted'` sessions in DB on startup and offers resume |
+| `RateLimiter` | Token bucket per exchange (services/rate_limiter.py) |
+
+### Configuration
+
+All tunable constants live in `configs.py`:
+- `PROFIT_CRITERIA_PCT` / `PROFIT_CRITERIA_USD` — minimum spread thresholds to fire a trade
+- `EXCHANGE_FEES` — per-exchange maker/taker rates used in profit calculation
+- `RISK_CONFIG` — drawdown, loss, slippage, cooldown limits
+- `SUPPORTED_EXCHANGES` — `['kucoin', 'binance', 'bybit', 'okx', 'kucoinfutures']`
+
+### Environment variables (`.env`)
+
+```
+BINANCE_API_KEY / BINANCE_SECRET
+KUCOIN_API_KEY / KUCOIN_SECRET / KUCOIN_PASSWORD
+OKX_API_KEY / OKX_SECRET / OKX_PASSWORD
+BYBIT_API_KEY / BYBIT_SECRET
+TELEGRAM_TOKEN / CHAT_ID
+USE_SANDBOX=true          # routes to testnet keys (BINANCE_TESTNET_API_KEY etc.)
+ENABLE_TELEGRAM=true
+ENABLE_CTRL_C_HANDLING=true
+```
+
+### Backtest framework
+
+`backtest/data_recorder.py` records live orderbook snapshots to SQLite. `backtest/engine.py` replays them and supports parameter sweeps. `backtest/analyzer.py` computes win rate, Sharpe ratio, and max drawdown. Tests in `tests/test_backtest.py`.
+
+### Web dashboard
+
+FastAPI app at `web/app.py` serves Jinja2 templates and a REST API. Key routes: `/dashboard`, `/getting-started`, `/docs` (OpenAPI). Reads from `DatabaseService` for session/trade history.
+
+### Custom exceptions (`utils/exceptions.py`)
+
+All exceptions inherit from `ArbitrageError`. Key types: `ExchangeError`, `InsufficientBalanceError`, `OrderError`, `OrderFillTimeoutError`, `FuturesError`, `DeltaNeutralError`.
+
+## Testing notes
+
+- Tests use `tempfile`-backed SQLite instances — never the live `data/arbitrage.db`.
+- Exchange interactions are mocked with `unittest.mock.MagicMock` / `AsyncMock`; do not add real network calls to tests.
+- CI runs on Python 3.10, 3.11, 3.12 (see `.github/workflows/pylint.yml`).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Bot giao dịch chênh lệch giá crypto tự động giữa nhiều sàn. Hỗ
 - **Web dashboard**: FastAPI + Jinja2 theo dõi giao dịch qua trình duyệt
 - **Backtesting**: Replay dữ liệu lịch sử, parameter sweep, phân tích metrics
 - **Telegram alerts**: Thông báo cơ hội, giao dịch, lỗi qua Telegram
+- **Session Recovery**: 🆕 Khôi phục tự động phiên bị dừng do lỗi hoặc ngắt kết nối
 
 ## Cấu trúc dự án
 
@@ -75,6 +76,7 @@ pip install -r requirements.txt
 Người mới nên bắt đầu bằng paper trading trước khi cấu hình API key thật.
 
 - Tài liệu đầy đủ: [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md)
+- **Khôi phục phiên bị dừng**: [docs/SESSION_RECOVERY.md](docs/SESSION_RECOVERY.md) 🆕
 - Hướng dẫn trên web: chạy `python -m uvicorn web.app:app --reload --port 8000`, rồi mở `http://localhost:8000/getting-started`
 - Lệnh an toàn đầu tiên: `python -m bots.demo_fake_bot --symbol BTC/USDT --exchanges binance okx bybit --duration 5`
 

--- a/bots/base_bot.py
+++ b/bots/base_bot.py
@@ -267,14 +267,17 @@ class BaseBot:
     async def process_orderbook(self, exchange_id: str, orderbook: dict[str, Any]) -> bool:
         """
         Xử lý dữ liệu sách lệnh nhận được từ sàn giao dịch.
-        
+
         Args:
             exchange_id (str): ID của sàn giao dịch
             orderbook (dict): Dữ liệu sách lệnh
-            
+
         Returns:
             bool: True nếu phát hiện cơ hội giao dịch, ngược lại False
         """
+        if not orderbook.get("bids") or not orderbook.get("asks"):
+            return False
+
         # Cập nhật giá mua và bán tốt nhất
         self.bid_prices[exchange_id] = orderbook["bids"][0][0]  # Giá mua cao nhất
         self.ask_prices[exchange_id] = orderbook["asks"][0][0]  # Giá bán thấp nhất
@@ -387,6 +390,10 @@ class BaseBot:
         Returns:
             bool: True nếu nên thực hiện giao dịch, ngược lại False
         """
+        # Bảo vệ: crypto_per_transaction phải được khởi tạo trước khi giao dịch
+        if self.crypto_per_transaction <= 0:
+            return False
+
         # Điều kiện cơ bản: sàn mua và bán phải khác nhau
         if min_ask_ex == max_bid_ex:
             return False

--- a/bots/classic_bot.py
+++ b/bots/classic_bot.py
@@ -82,7 +82,12 @@ class ClassicBot(BaseBot):
             
             # Kiểm tra số dư
             try:
-                self.balance_service.check_balances(self.exchanges, 'USDT', self.howmuchusd, self.notification_service)
+                await self.balance_service.check_balances(
+                    self.exchanges,
+                    'USDT',
+                    self.howmuchusd,
+                    self.notification_service
+                )
             except InsufficientBalanceError as e:
                 log_error(f"Không đủ số dư: {str(e)}")
                 self.error_counts['balance'] += 1
@@ -102,7 +107,7 @@ class ClassicBot(BaseBot):
                     prices = []
                     for exchange_id in self.exchanges:
                         try:
-                            ticker = self.exchange_service.get_ticker(exchange_id, self.symbol)
+                            ticker = await self.exchange_service.get_ticker(exchange_id, self.symbol)
                             prices.append((ticker['bid'] + ticker['ask']) / 2)
                         except Exception:
                             continue

--- a/bots/delta_neutral_bot.py
+++ b/bots/delta_neutral_bot.py
@@ -85,7 +85,7 @@ class DeltaNeutralBot(BaseBot):
             
             # Kiểm tra số dư trên các sàn spot
             try:
-                self.balance_service.check_balances(
+                await self.balance_service.check_balances(
                     self.exchanges, 
                     'USDT', 
                     spot_investment, 
@@ -97,7 +97,7 @@ class DeltaNeutralBot(BaseBot):
             
             # Kiểm tra số dư trên sàn futures
             try:
-                futures_balance = self.balance_service.get_balance(self.futures_exchange, 'USDT')
+                futures_balance = await self.balance_service.get_balance(self.futures_exchange, 'USDT')
                 
                 # Nếu số dư trên sàn futures không đủ, chuyển tiền từ spot sang futures
                 if futures_balance < futures_investment:

--- a/bots/fake_money_bot.py
+++ b/bots/fake_money_bot.py
@@ -3,11 +3,12 @@ Bot mô phỏng giao dịch với tiền ảo, không thực hiện giao dịch 
 """
 import time
 import asyncio
+import traceback
 from asyncio import gather
 from typing import Any, Optional
 import ccxt.pro
 
-from utils.logger import log_info, log_error, log_warning
+from utils.logger import log_info, log_error, log_warning, log_debug
 from utils.exceptions import ArbitrageError
 from utils.helpers import calculate_average
 from bots.base_bot import BaseBot
@@ -127,9 +128,10 @@ class FakeMoneyBot(BaseBot):
         Returns:
             None
         """
+        pro_exchange = None
         try:
             # Tạo đối tượng sàn giao dịch ccxt.pro
-            pro_exchange = await self.exchange_service.get_pro_exchange(exchange_id)
+            pro_exchange = await self.exchange_service.get_pro_exchange(exchange_id, public_only=True)
             
             # Theo dõi sách lệnh cho đến khi hết thời gian
             while time.time() <= self.timeout:
@@ -142,13 +144,18 @@ class FakeMoneyBot(BaseBot):
                     
                 except Exception as loop_error:
                     log_error(f"Lỗi trong vòng lặp {exchange_id}: {str(loop_error)}")
+                    log_debug(f"Chi tiết lỗi {exchange_id}: {type(loop_error).__name__}: {repr(loop_error)}")
+                    log_debug(traceback.format_exc())
                     break
-            
-            # Đóng kết nối với sàn giao dịch
-            await pro_exchange.close()
             
         except Exception as e:
             log_error(f"Lỗi khi khởi tạo vòng lặp cho {exchange_id}: {str(e)}")
+        finally:
+            if pro_exchange:
+                try:
+                    await pro_exchange.close()
+                except Exception:
+                    pass
     
     async def _execute_trade(self, min_ask_ex: str, max_bid_ex: str,
                              profit_with_fees_pct: float, profit_with_fees_usd: float) -> None:

--- a/configs.py
+++ b/configs.py
@@ -13,12 +13,12 @@ ENABLE_TELEGRAM = os.getenv('ENABLE_TELEGRAM', 'false').lower() == 'true'
 ENABLE_CTRL_C_HANDLING = os.getenv('ENABLE_CTRL_C_HANDLING', 'false').lower() == 'true'
 
 # Tiêu chí lợi nhuận
-PROFIT_CRITERIA_PCT = 0  # % lợi nhuận tối thiểu
-PROFIT_CRITERIA_USD = 0  # Lợi nhuận USD tối thiểu
+PROFIT_CRITERIA_PCT = 0.05  # % lợi nhuận tối thiểu (đủ bù phí ~0.1-0.2%)
+PROFIT_CRITERIA_USD = 0.5   # Lợi nhuận USD tối thiểu
 
 # Thông số giao dịch
 BETTER_FILL_LESS_PROFITS = True  # Điều chỉnh fill để giảm lợi nhuận
-FIRST_ORDERS_FILL_TIMEOUT = 3600  # Thời gian chờ tối đa để fill đơn hàng đầu tiên (giây)
+FIRST_ORDERS_FILL_TIMEOUT = 300  # Thời gian chờ tối đa để fill đơn hàng đầu tiên (giây)
 
 # Danh sách các sàn giao dịch hỗ trợ
 SUPPORTED_EXCHANGES = ['kucoin', 'binance', 'bybit', 'okx', 'kucoinfutures']

--- a/docs/SESSION_RECOVERY.md
+++ b/docs/SESSION_RECOVERY.md
@@ -1,0 +1,216 @@
+# Hướng dẫn khôi phục phiên giao dịch
+
+## Tính năng mới: Session Recovery (Khôi phục Phiên)
+
+Bot hiện nay hỗ trợ khôi phục tự động các phiên bị dừng do lỗi hoặc ngắt kết nối. Điều này giúp bạn tiếp tục giao dịch từ điểm dừng mà không mất dữ liệu.
+
+## Cách hoạt động
+
+### 1. **Phát hiện phiên bị dừng**
+- Khi bot bắt đầu chạy, nó sẽ kiểm tra database để tìm các phiên có `status = 'running'` (chưa hoàn thành)
+- Nếu tìm thấy, bot sẽ hiển thị danh sách các phiên bị dừng
+
+### 2. **Hỏi người dùng**
+Bạn sẽ thấy menu như sau:
+```
+================================================================================
+Phát hiện 1 phiên bị dừng:
+================================================================================
+
+[1] Phiên #5:
+    Chế độ: fake-money
+    Cặp tiền: BTC/USDT
+    Sàn: binance,kucoin,okx
+    Vốn: 1000 USDT
+    Thời gian bắt đầu: 2026-05-12T10:30:45.123456+00:00
+    Giao dịch đã thực hiện: 12
+    Lợi nhuận: 0.5234% (5.2340 USDT)
+
+================================================================================
+Tùy chọn:
+  [1] - Khôi phục phiên
+  [0 hoặc Enter] - Chạy phiên mới
+
+Lựa chọn của bạn: 
+```
+
+### 3. **Khôi phục**
+Nếu bạn chọn khôi phục (nhập `1`):
+- Bot sẽ tải lại cấu hình phiên cũ (chế độ, cặp tiền, sàn, vốn, v.v.)
+- Khôi phục balance từ file `balance.txt`
+- Đánh dấu phiên cũ là `resumed`
+- Tiếp tục giao dịch với cấu hình đó
+
+## Các tình huống sử dụng
+
+### 1. **Mất kết nối mạng**
+```bash
+# Bot đang chạy khi mất internet
+# Sau khi kết nối lại, khởi động bot bình thường:
+python main.py fake-money 15 1000 binance kucoin okx BTC/USDT
+
+# Bot sẽ phát hiện phiên bị dừng và hỏi có muốn khôi phục không
+```
+
+### 2. **Bot crash**
+```bash
+# Bot bị crash do lỗi (ví dụ: exchange API error)
+# Kiểm tra logs để debug
+tail -f logs/arbitrage_bot_*.log
+
+# Sau khi fix lỗi, khởi động lại:
+python main.py fake-money 15 1000 binance kucoin okx BTC/USDT
+
+# Chọn khôi phục phiên để tiếp tục
+```
+
+### 3. **Người dùng thoát chương trình**
+```bash
+# Nhấn Ctrl+C khi bot đang chạy
+# Bot sẽ hỏi có muốn bán tất cả crypto không
+
+# Nếu thoát mà không bán (nhấn N):
+# Phiên sẽ được lưu với status = 'running'
+
+# Lần khởi động tiếp theo:
+python main.py fake-money 15 1000 binance kucoin okx BTC/USDT
+
+# Chọn khôi phục phiên để tiếp tục
+```
+
+## Tình trạng phiên (Session Status)
+
+| Status | Ý nghĩa |
+|--------|---------|
+| `running` | Phiên đang chạy hoặc bị dừng (chưa hoàn thành) |
+| `completed` | Phiên hoàn thành bình thường |
+| `interrupted` | Phiên bị dừng bất thường (lỗi) |
+| `resumed` | Phiên đã được khôi phục lần trước |
+| `error` | Phiên kết thúc do lỗi |
+
+## Dữ liệu được lưu trữ cho recovery
+
+Khi phiên bị dừng, bot lưu trữ:
+- **Cấu hình phiên**: chế độ, cặp tiền, sàn, vốn, thời gian làm mới
+- **Dữ liệu giao dịch**: tất cả giao dịch đã thực hiện
+- **Balance snapshots**: số dư cuối của mỗi sàn
+- **Lợi nhuận tích lũy**: tổng lợi nhuận từ các giao dịch trước
+- **Thông tin lỗi**: nếu có exception
+
+## Cách tắt tính năng recovery
+
+Nếu bạn muốn chạy phiên mới mà không khôi phục:
+
+```bash
+# Cách 1: Chọn "0" hoặc nhấn Enter khi menu hỏi
+Lựa chọn của bạn: 0
+
+# Cách 2: Sử dụng flag --no-recovery (tuỳ chọn)
+python main.py fake-money 15 1000 binance kucoin okx BTC/USDT --no-recovery
+```
+
+## Xem lịch sử phiên trên Dashboard
+
+Để xem danh sách tất cả phiên (kể cả những phiên bị dừng):
+
+```bash
+# Chạy web dashboard
+python -m uvicorn web.app:app --reload --port 8000
+
+# Mở trình duyệt: http://localhost:8000/dashboard
+```
+
+Dashboard sẽ hiển thị:
+- Tất cả phiên (running, completed, interrupted, resumed)
+- Chi tiết giao dịch của mỗi phiên
+- Lợi nhuận/lỗ
+- Balance snapshots
+
+## API Query để kiểm tra phiên bị dừng
+
+Nếu bạn muốn kiểm tra trực tiếp database:
+
+```python
+from services.database_service import DatabaseService
+
+db = DatabaseService()
+
+# Lấy danh sách phiên bị dừng
+interrupted = db.get_interrupted_sessions()
+for session in interrupted:
+    print(f"Phiên #{session['id']}: {session['mode']} - {session['symbol']}")
+    print(f"  Status: {session['status']}")
+    print(f"  Giao dịch: {session['trades_executed']}")
+    print(f"  Lợi nhuận: {session['total_profit_pct']:.4f}%\n")
+
+# Lấy thông tin chi tiết phiên
+recovery_info = db.get_session_recovery_info(session_id=5)
+print(f"Khôi phục: {recovery_info}")
+
+# Xem giao dịch cuối cùng
+last_trade = db.get_last_trade(session_id=5)
+print(f"Giao dịch cuối: {last_trade}")
+```
+
+## Ghi chú quan trọng
+
+### ⚠️ Dữ liệu Balance
+- **Đọc từ `balance.txt`**: Vốn sẽ được lấy từ file `balance.txt` (được cập nhật sau mỗi phiên)
+- **Nếu bạn đã rút tiền**: Cập nhật số dư trong `balance.txt` trước khi khôi phục
+
+### ⚠️ Timeout vẫn được tính từ lúc khôi phục
+- Nếu phiên cũ timeout là 15 phút từ 10:00 -> 10:15
+- Sau khi khôi phục lúc 14:00, timeout sẽ là 15 phút từ 14:00 -> 14:15
+- Bạn có thể muốn điều chỉnh lại timeout khi khôi phục
+
+### ✅ Best Practices
+
+1. **Kiểm tra logs**: Xem logs để debug lý do tại sao phiên bị dừng
+2. **Cập nhật balance**: Cập nhật `balance.txt` nếu bạn đã rút/gửi tiền
+3. **Xem dashboard**: Kiểm tra kết quả phiên cũ trước khi khôi phục
+4. **Test dry-run trước**: Nếu không chắc chắn, dùng `--dry-run` để test
+
+## Troubleshooting
+
+### Q: Bot không nhận ra phiên bị dừng?
+**A**: 
+- Kiểm tra database tại `data/arbitrage.db`
+- Xem logs để kiểm tra lỗi
+- Kiểm tra database connection: `sqlite3 data/arbitrage.db "SELECT * FROM sessions WHERE status='running'"`
+
+### Q: Phiên khôi phục nhưng không tiếp tục từ điểm cũ?
+**A**: 
+- Bot sẽ bắt đầu với cấu hình cũ nhưng sẽ tạo một số hiệu giao dịch mới
+- Lợi nhuận trước đó sẽ được hiển thị và tích lũy
+
+### Q: Tôi muốn xóa phiên bị dừng?
+**A**: 
+- Hiện tại, chọn "0" khi hỏi sẽ bắt đầu phiên mới (phiên cũ sẽ vẫn được lưu)
+- Để xóa từ database: `sqlite3 data/arbitrage.db "DELETE FROM sessions WHERE id=5"`
+- Hoặc chỉnh sửa status thành `'completed'`: `sqlite3 data/arbitrage.db "UPDATE sessions SET status='completed' WHERE id=5"`
+
+### Q: Recovery không hoạt động khi chạy multi-pair?
+**A**: 
+- Multi-pair mode hiện chưa hỗ trợ recovery đầy đủ
+- Phiên bị dừng sẽ được phát hiện, nhưng bạn cần chạy lại từ đầu
+- Recovery tốt nhất dành cho single-pair mode
+
+## Giới hạn hiện tại
+
+- ❌ Không thể resume pending orders (chưa hoàn thành)
+- ❌ Multi-pair recovery không đầy đủ
+- ⚠️ Timeout được tính từ khi khôi phục (không tiếp tục từ timeout cũ)
+- ⚠️ Không tự động retry nếu khôi phục lỗi
+
+## Phát triển tiếp theo
+
+Những cải tiến dự kiến:
+- [ ] Tự động khôi phục nếu phiên bị dừng > X phút
+- [ ] Quản lý pending orders khi khôi phục
+- [ ] Heartbeat checkpoint (lưu trạng thái mỗi phút)
+- [ ] Recovery support cho multi-pair mode
+- [ ] Tính lại timeout từ điểm gốc
+
+---
+
+**Câu hỏi hay đóng góp?** Vui lòng mở issue trên GitHub: https://github.com/nguyenngocbinhneu/bmlb-arbitrage-bot/issues

--- a/examples/session_recovery_examples.py
+++ b/examples/session_recovery_examples.py
@@ -1,0 +1,208 @@
+"""
+Ví dụ: Sử dụng Session Recovery trong Bot
+
+Tệp này minh họa cách khôi phục phiên bị dừng bằng SessionRecovery utility.
+"""
+import sys
+import os
+
+# Thêm thư mục gốc vào path để import
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from services.database_service import DatabaseService
+from utils.session_recovery import SessionRecovery
+from utils.logger import safe_print
+
+
+# ============================================================================
+# EXAMPLE 1: Kiểm tra phiên bị dừng (interrupt)
+# ============================================================================
+
+def example_check_interrupted():
+    """Kiểm tra xem có phiên nào bị dừng không."""
+    db = DatabaseService()
+    recovery = SessionRecovery(db)
+    
+    interrupted = recovery.get_interrupted_sessions()
+    
+    if not interrupted:
+        safe_print("No interrupted sessions found")
+    else:
+        safe_print(f"Found {len(interrupted)} interrupted sessions:")
+        for session in interrupted:
+            safe_print(f"  - Session #{session['id']}: {session['symbol']} ({session['mode']})")
+
+
+# ============================================================================
+# EXAMPLE 2: Lấy thông tin khôi phục phiên
+# ============================================================================
+
+def example_get_recovery_info(session_id):
+    """Lấy thông tin chi tiết để khôi phục phiên."""
+    db = DatabaseService()
+    recovery = SessionRecovery(db)
+    
+    recovery_info = recovery.get_recovery_info(session_id)
+    
+    if recovery_info:
+        safe_print(f"Recovery info for session #{session_id}:")
+        safe_print(f"  Mode: {recovery_info['mode']}")
+        safe_print(f"  Symbol: {recovery_info['symbol']}")
+        safe_print(f"  Exchanges: {', '.join(recovery_info['exchanges'])}")
+        safe_print(f"  USDT Amount: {recovery_info['usdt_amount']}")
+        safe_print(f"  Trades Executed: {recovery_info['trades_executed']}")
+        safe_print(f"  Cumulative Profit: {recovery_info['cumulative_profit_pct']:.4f}%")
+        safe_print(f"  Cumulative Profit USD: {recovery_info['cumulative_profit_usd']:.4f}")
+        safe_print(f"  Start Time: {recovery_info['start_time']}")
+        
+        # Lấy tham số để chạy bot
+        params = SessionRecovery.extract_recovery_params(recovery_info)
+        safe_print("\n  Bot parameters:")
+        safe_print(
+            f"    python main.py {params['mode']} {params['renew_time']} {params['usdt_amount']} "
+            f"{' '.join(params['exchanges'])} {params['symbol']}"
+        )
+
+
+# ============================================================================
+# EXAMPLE 3: Đánh dấu phiên là interrupted (khi có lỗi)
+# ============================================================================
+
+def example_mark_interrupted(session_id, error_message):
+    """Đánh dấu phiên là bị interrupt do lỗi."""
+    db = DatabaseService()
+    recovery = SessionRecovery(db)
+    
+    recovery.mark_interrupted(session_id, error_message)
+    safe_print(f"Session #{session_id} was marked as interrupted")
+
+
+# ============================================================================
+# EXAMPLE 4: Đánh dấu phiên là resumed (khi khôi phục thành công)
+# ============================================================================
+
+def example_mark_resumed(session_id):
+    """Đánh dấu phiên đã được khôi phục."""
+    db = DatabaseService()
+    recovery = SessionRecovery(db)
+    
+    recovery.mark_resumed(session_id)
+    safe_print(f"Session #{session_id} was marked as resumed")
+
+
+# ============================================================================
+# EXAMPLE 5: Luồng khôi phục phiên hoàn chỉnh
+# ============================================================================
+
+def example_full_recovery_flow():
+    """Luồng khôi phục phiên hoàn chỉnh."""
+    db = DatabaseService()
+    recovery = SessionRecovery(db)
+    
+    safe_print("SESSION RECOVERY FLOW\n")
+    
+    # Step 1: Kiểm tra phiên bị dừng
+    safe_print("Step 1: Check interrupted sessions...")
+    interrupted = recovery.get_interrupted_sessions()
+    
+    if not interrupted:
+        safe_print("  -> No interrupted sessions found")
+        return
+    
+    safe_print(f"  -> Found {len(interrupted)} interrupted sessions")
+    
+    # Step 2: Hỏi người dùng (thường thấy trong main.py)
+    safe_print("\nStep 2: Show the prompt menu...")
+    safe_print("  (In main.py, this is the interactive recovery menu)")
+    
+    # Step 3: Lấy thông tin phiên được chọn
+    session_id = interrupted[0]['id']
+    safe_print(f"\nStep 3: Load recovery info for session #{session_id}...")
+    recovery_info = recovery.get_recovery_info(session_id)
+    
+    if recovery_info:
+        safe_print(f"  -> Mode: {recovery_info['mode']}")
+        safe_print(f"  -> Symbol: {recovery_info['symbol']}")
+        safe_print(f"  -> Previous trades: {recovery_info['trades_executed']}")
+        safe_print(f"  -> Cumulative profit: {recovery_info['cumulative_profit_pct']:.4f}%")
+    
+    # Step 4: Trích xuất tham số
+    safe_print("\nStep 4: Extract bot parameters...")
+    params = SessionRecovery.extract_recovery_params(recovery_info)
+    safe_print(f"  -> Mode: {params['mode']}")
+    safe_print(f"  -> Symbol: {params['symbol']}")
+    safe_print(f"  -> Exchanges: {params['exchanges']}")
+    
+    # Step 5: Khôi phục (trong main.py, bot sẽ chạy lại với tham số này)
+    safe_print("\nStep 5: Restart the bot with the recovered configuration")
+    safe_print("  -> The session continues from the interruption point")
+    safe_print("  -> Previous profit is carried forward")
+    
+    # Step 6: Đánh dấu resumed khi khôi phục thành công
+    safe_print("\nStep 6: After the bot finishes, the session is marked as 'resumed'")
+    # recovery.mark_resumed(session_id)  # Không chạy trong ví dụ này
+
+
+# ============================================================================
+# EXAMPLE 6: Xem lịch sử tất cả phiên (bao gồm interrupted)
+# ============================================================================
+
+def example_view_all_sessions():
+    """Xem tất cả phiên, bao gồm những phiên bị dừng."""
+    db = DatabaseService()
+    
+    # Xem tất cả phiên
+    all_sessions = db.get_all_sessions(limit=100)
+    
+    safe_print("ALL SESSIONS:")
+    safe_print("=" * 80)
+    
+    for session in all_sessions:
+        status_symbol = {
+            'running': '[RUNNING]',
+            'completed': '[DONE]',
+            'interrupted': '[INTERRUPTED]',
+            'resumed': '[RESUMED]',
+            'error': '[ERROR]'
+        }.get(session['status'], '[UNKNOWN]')
+        
+        safe_print(f"{status_symbol} Session #{session['id']}")
+        safe_print(f"   Mode: {session['mode']} | Symbol: {session['symbol']}")
+        safe_print(f"   Status: {session['status']} | Time: {session['renew_time_minutes']} min")
+        safe_print(f"   Profit: {session['total_profit_pct']:.4f}% ({session['total_profit_usd']:.4f} USD)")
+        safe_print(f"   Trades: {session['trades_executed']} | Opportunities: {session['opportunities_found']}")
+        safe_print('')
+
+
+# ============================================================================
+# MAIN: Chạy ví dụ
+# ============================================================================
+
+if __name__ == "__main__":
+    import sys
+    
+    if len(sys.argv) < 2:
+        safe_print("Usage:")
+        safe_print("  python examples/session_recovery_examples.py check     # List interrupted sessions")
+        safe_print("  python examples/session_recovery_examples.py info <id> # Show recovery info")
+        safe_print("  python examples/session_recovery_examples.py flow      # Show recovery flow")
+        safe_print("  python examples/session_recovery_examples.py all       # List all sessions")
+        sys.exit(1)
+    
+    command = sys.argv[1]
+    
+    if command == "check":
+        example_check_interrupted()
+    elif command == "info" and len(sys.argv) > 2:
+        try:
+            session_id = int(sys.argv[2])
+            example_get_recovery_info(session_id)
+        except ValueError:
+            safe_print("Error: Session ID must be a number")
+    elif command == "flow":
+        example_full_recovery_flow()
+    elif command == "all":
+        example_view_all_sessions()
+    else:
+        safe_print(f"Invalid command: {command}")
+        safe_print("Valid commands: check, info, flow, all")

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ import asyncio
 import argparse
 import logging
 import concurrent.futures
+import aiohttp
 from colorama import Style, Fore, init
 from dotenv import load_dotenv
 
@@ -33,9 +34,24 @@ from bots.delta_neutral_bot import DeltaNeutralBot
 from bots.fake_money_bot import FakeMoneyBot
 
 # Import các module tiện ích
-from utils.logger import log_info, log_error, log_warning, logger
+from utils.logger import log_info, log_error, log_warning, logger, safe_print, configure_console_encoding
 from utils.helpers import show_time
+from utils.session_recovery import SessionRecovery
 from configs import PYTHON_COMMAND, ENABLE_TELEGRAM, BOT_MODES
+
+configure_console_encoding()
+
+
+def configure_async_dns_resolver() -> None:
+    """Chuyển aiohttp sang threaded resolver trên Windows để tránh lỗi DNS của aiodns."""
+    if sys.platform != 'win32':
+        return
+
+    aiohttp.connector.DefaultResolver = aiohttp.ThreadedResolver
+    aiohttp.resolver.DefaultResolver = aiohttp.ThreadedResolver
+
+
+configure_async_dns_resolver()
 
 
 def setup_logging(level=logging.INFO):
@@ -67,7 +83,7 @@ def setup_logging(level=logging.INFO):
 
 def display_banner():
     """Hiển thị banner khi khởi động ứng dụng."""
-    print("""
+    safe_print("""
                 ╔═╗─╔╗────────────────╔═╗─╔╗─────────╔══╗───╔╗
                 ║║╚╗║║────────────────║║╚╗║║─────────║╔╗║───║║
                 ║╔╗╚╝╠══╦╗╔╦╗─╔╦══╦═╗─║╔╗╚╝╠══╦══╦══╗║╚╝╚╦═╗║╚═╗
@@ -77,8 +93,8 @@ def display_banner():
                 ─────╔═╝║──╔═╝║────────────╔═╝║
                 ─────╚══╝──╚══╝────────────╚══╝
     """)
-    print(f"\n{Fore.CYAN}BMLB Arbitrage Bot{Style.RESET_ALL} - Giao dịch chênh lệch giá crypto tự động")
-    print("\nGithub: nguyenngocbinh\nTwitter: @nanabi88\n")
+    safe_print(f"\n{Fore.CYAN}BMLB Arbitrage Bot{Style.RESET_ALL} - Giao dịch chênh lệch giá crypto tự động")
+    safe_print("\nGithub: nguyenngocbinh\nTwitter: @nanabi88\n")
 
 
 def parse_arguments():
@@ -107,6 +123,7 @@ def parse_arguments():
     parser.add_argument('--debug', action='store_true', help='Kích hoạt chế độ debug')
     parser.add_argument('--no-banner', action='store_true', help='Không hiển thị banner')
     parser.add_argument('--dry-run', action='store_true', help='Chạy mà không thực hiện giao dịch thực tế')
+    parser.add_argument('--no-recovery', action='store_true', help='Bỏ qua khôi phục phiên bị dừng')
     parser.add_argument('--symbols', nargs='+', help='Nhiều cặp giao dịch (vd: --symbols BTC/USDT ETH/USDT)')
     
     return parser.parse_args()
@@ -174,7 +191,7 @@ async def find_best_symbol(exchange_service, exchanges):
                 
                 # Thu thập giá từ các sàn
                 for exchange_id in exchanges:
-                    ticker = exchange_service.get_ticker(exchange_id, pair)
+                    ticker = await exchange_service.get_ticker(exchange_id, pair)
                     bid_prices[exchange_id] = ticker['bid']
                     ask_prices[exchange_id] = ticker['ask']
                 
@@ -245,6 +262,11 @@ async def run_bot(mode, symbol, usdt_amount, renew_time, exchanges, dry_run=Fals
     Returns:
         float: Tổng lợi nhuận (phần trăm)
     """
+    bot = None
+    db_service = None
+    recovery = None
+    exchange_service = None
+    
     try:
         # Khởi tạo các dịch vụ
         exchange_service = ExchangeService()
@@ -252,6 +274,7 @@ async def run_bot(mode, symbol, usdt_amount, renew_time, exchanges, dry_run=Fals
         order_service = OrderService(exchange_service)
         notification_service = NotificationService(ENABLE_TELEGRAM)
         db_service = DatabaseService()
+        recovery = SessionRecovery(db_service)
         
         # Log thông tin khởi động
         log_info(f"Khởi động bot với chế độ: {mode}, số tiền: {usdt_amount} USDT, thời gian làm mới: {renew_time} phút")
@@ -309,18 +332,42 @@ async def run_bot(mode, symbol, usdt_amount, renew_time, exchanges, dry_run=Fals
         
         # Chạy bot
         start_time = time.time()
-        profit_pct = await bot.start()
-        end_time = time.time()
-        
-        # Log thông tin kết thúc
-        elapsed_time = time.strftime('%H:%M:%S', time.gmtime(end_time - start_time))
-        log_info(f"Bot đã kết thúc sau {elapsed_time}. Tổng lợi nhuận: {profit_pct:.4f}%")
-        
-        return profit_pct
+        try:
+            profit_pct = await bot.start()
+            end_time = time.time()
+            
+            # Log thông tin kết thúc
+            elapsed_time = time.strftime('%H:%M:%S', time.gmtime(end_time - start_time))
+            log_info(f"Bot đã kết thúc sau {elapsed_time}. Tổng lợi nhuận: {profit_pct:.4f}%")
+            
+            return profit_pct
+            
+        except KeyboardInterrupt:
+            # Khi Ctrl+C, phiên sẽ được xử lý bởi bot.stop() trong signal handler
+            raise
+        except Exception as e:
+            # Nếu xảy ra lỗi trong bot, đánh dấu session là interrupted
+            error_msg = f"Lỗi trong khi chạy bot: {str(e)}"
+            log_error(error_msg)
+            
+            if bot and bot.session_id and db_service:
+                try:
+                    log_warning(f"Đánh dấu phiên #{bot.session_id} là interrupted")
+                    recovery.mark_interrupted(bot.session_id, error_msg)
+                except Exception as recovery_error:
+                    log_error(f"Lỗi khi đánh dấu phiên interrupted: {str(recovery_error)}")
+            
+            raise
         
     except Exception as e:
         log_error(f"Lỗi khi chạy bot: {str(e)}")
         return 0
+    finally:
+        if exchange_service:
+            try:
+                await exchange_service.close_all_pro_exchanges()
+            except Exception as close_error:
+                log_warning(f"Không thể đóng toàn bộ kết nối pro: {str(close_error)}")
 
 
 async def main():
@@ -328,6 +375,10 @@ async def main():
     try:
         # Thiết lập logging
         setup_logging()
+        
+        # Khởi tạo database service để kiểm tra phiên bị dừng
+        db_service = DatabaseService()
+        recovery = SessionRecovery(db_service)
         
         # Nếu có tham số dòng lệnh
         if len(sys.argv) > 1:
@@ -348,7 +399,9 @@ async def main():
             exchanges = [args.exchange1, args.exchange2, args.exchange3]
             symbol = args.symbol
             dry_run = args.dry_run
+            no_recovery = args.no_recovery
             symbols = args.symbols  # Multi-pair
+            recovered_session_id = None
             
         # Nếu không có tham số dòng lệnh, lấy thông tin từ người dùng
         else:
@@ -363,7 +416,43 @@ async def main():
             exchanges = [inputs["exchange_1"], inputs["exchange_2"], inputs["exchange_3"]]
             symbol = inputs["crypto"] if inputs["crypto"] else None
             dry_run = False  # Mặc định không phải dry run khi nhập thủ công
+            no_recovery = False
             symbols = None  # Manual mode không hỗ trợ multi-pair
+            recovered_session_id = None
+        
+        # ─── PHÁT HIỆN & KHÔI PHỤC PHIÊN BỊ DỪNG ─────────────────────────
+        # Kiểm tra xem có phiên bị dừng chưa được khôi phục
+        interrupted_sessions = recovery.get_interrupted_sessions()
+        if interrupted_sessions and not no_recovery:
+            safe_print('')
+            recovered_session_id = recovery.show_interrupted_sessions()
+            
+            if recovered_session_id:
+                # Lấy thông tin khôi phục
+                recovery_info = recovery.get_recovery_info(recovered_session_id)
+                
+                if recovery_info:
+                    # Sử dụng thông tin từ phiên cũ để khôi phục
+                    mode = recovery_info['mode']
+                    symbol = recovery_info['symbol']
+                    usdt_amount = recovery_info['usdt_amount']
+                    renew_time = recovery_info['renew_time_minutes']
+                    exchanges = recovery_info['exchanges']
+                    
+                    log_info(f"Khôi phục phiên #{recovered_session_id}")
+                    log_info(f"Lợi nhuận trước đó: {recovery_info['cumulative_profit_pct']:.4f}%")
+                    
+                    # Tạo vốn mới từ balance file (hoặc sử dụng số dư cuối từ phiên cũ)
+                    try:
+                        with open('balance.txt', 'r') as f:
+                            usdt_amount = float(f.read().strip())
+                            log_info(f"Sử dụng balance từ balance.txt: {usdt_amount} USDT")
+                    except Exception as e:
+                        log_warning(f"Không thể đọc balance.txt, sử dụng vốn từ phiên cũ: {str(e)}")
+            else:
+                safe_print('')
+        
+        # ─── KẾT THÚC PHÁT HIỆN PHIÊN ─────────────────────────────────────
         
         # Kiểm tra chế độ
         if mode not in BOT_MODES:

--- a/services/async_order_service.py
+++ b/services/async_order_service.py
@@ -263,6 +263,19 @@ class AsyncOrderService:
                 raise OrderError(f"{min_ask_ex}/{max_bid_ex}", "arbitrage",
                                  "Cả hai lệnh đều thất bại")
 
+            # Xử lý lệch vị thế: một lệnh thành công, một lệnh thất bại
+            if buy_success and not sell_success:
+                log_warning(f"Sell thất bại trên {max_bid_ex}, đang đảo lệnh mua trên {min_ask_ex}...")
+                await self._emergency_reverse_buy(min_ask_ex, symbol, amount, notification_service)
+                fill_result['success'] = False
+                return fill_result
+
+            if sell_success and not buy_success:
+                log_warning(f"Buy thất bại trên {min_ask_ex}, đang đảo lệnh bán trên {max_bid_ex}...")
+                await self._emergency_reverse_sell(max_bid_ex, symbol, amount, notification_service)
+                fill_result['success'] = False
+                return fill_result
+
             fill_result['success'] = True
 
             # Chờ lệnh khớp (tối đa 3 phút) và cập nhật giá thực tế
@@ -548,6 +561,58 @@ class AsyncOrderService:
                 exchange_id,
                 f"Lỗi khi đợi lệnh futures khớp: {str(e)}"
             )
+
+    # ─── Position Recovery Helpers ────────────────────────────────────
+
+    async def _emergency_reverse_buy(self, exchange_id: str, symbol: str, amount: float,
+                                      notification_service=None) -> None:
+        """
+        Khi sell thất bại sau khi buy đã đặt: hủy lệnh mua nếu còn open,
+        hoặc bán market ngay nếu đã fill để đảo vị thế.
+        """
+        try:
+            open_orders = await self.exchange_service.async_fetch_open_orders(exchange_id, symbol)
+            if open_orders:
+                await self.exchange_service.async_cancel_order(
+                    exchange_id, open_orders[0]['id'], symbol
+                )
+                log_info(f"Đã hủy lệnh mua trên {exchange_id} (sell thất bại).")
+            else:
+                await self.exchange_service.async_create_market_sell_order(
+                    exchange_id, symbol, amount
+                )
+                log_warning(f"Lệnh mua đã fill — đã bán market trên {exchange_id} để đảo vị thế.")
+            if notification_service:
+                notification_service.send_message(
+                    f"⚠️ Đảo lệnh mua trên {exchange_id} — sell leg thất bại"
+                )
+        except Exception as e:
+            log_error(f"Lỗi khi đảo lệnh mua trên {exchange_id}: {str(e)}")
+
+    async def _emergency_reverse_sell(self, exchange_id: str, symbol: str, amount: float,
+                                       notification_service=None) -> None:
+        """
+        Khi buy thất bại sau khi sell đã đặt: hủy lệnh bán nếu còn open,
+        hoặc mua market ngay nếu đã fill để đảo vị thế.
+        """
+        try:
+            open_orders = await self.exchange_service.async_fetch_open_orders(exchange_id, symbol)
+            if open_orders:
+                await self.exchange_service.async_cancel_order(
+                    exchange_id, open_orders[0]['id'], symbol
+                )
+                log_info(f"Đã hủy lệnh bán trên {exchange_id} (buy thất bại).")
+            else:
+                await self.exchange_service.async_create_market_buy_order(
+                    exchange_id, symbol, amount
+                )
+                log_warning(f"Lệnh bán đã fill — đã mua market trên {exchange_id} để đảo vị thế.")
+            if notification_service:
+                notification_service.send_message(
+                    f"⚠️ Đảo lệnh bán trên {exchange_id} — buy leg thất bại"
+                )
+        except Exception as e:
+            log_error(f"Lỗi khi đảo lệnh bán trên {exchange_id}: {str(e)}")
 
     # ─── Slippage Helpers ─────────────────────────────────────────────
 

--- a/services/balance_service.py
+++ b/services/balance_service.py
@@ -27,8 +27,8 @@ class BalanceService:
         self.cache_time = {}  # Thời gian cache
         self.cache_timeout = 10  # Thời gian hết hạn cache (giây)
     
-    def check_balances(self, exchanges: list[str], symbol: str, total_amount: float,
-                       notification_service: Any = None) -> dict[str, dict[str, float]]:
+    async def check_balances(self, exchanges: list[str], symbol: str, total_amount: float,
+                             notification_service: Any = None) -> bool:
         """
         Kiểm tra số dư trên các sàn giao dịch.
         
@@ -51,7 +51,7 @@ class BalanceService:
         available_amount = 0
         
         for exchange_id in exchanges:
-            balance = self.get_balance(exchange_id, 'USDT')
+            balance = await self.get_balance(exchange_id, 'USDT')
             
             if balance < amount_per_exchange:
                 message = (
@@ -76,7 +76,7 @@ class BalanceService:
         
         return True
     
-    def get_balance(self, exchange_id: str, asset: str) -> float:
+    async def get_balance(self, exchange_id: str, asset: str) -> float:
         """
         Lấy số dư của một tài sản trên sàn giao dịch với caching.
         
@@ -95,7 +95,7 @@ class BalanceService:
             return self.cache[cache_key]
         
         # Nếu không có cache hoặc đã hết hạn, lấy số dư mới
-        balance = self.exchange_service.get_balance(exchange_id, asset)
+        balance = await self.exchange_service.async_get_balance(exchange_id, asset)
         
         # Cập nhật cache
         self.cache[cache_key] = balance

--- a/services/database_service.py
+++ b/services/database_service.py
@@ -864,3 +864,145 @@ class DatabaseService:
                 'buy_slippage': [dict(r) for r in buy_rows],
                 'sell_slippage': [dict(r) for r in sell_rows]
             }
+
+    # ─── Session Recovery ─────────────────────────────────────────────
+
+    def get_interrupted_sessions(self) -> list[dict[str, Any]]:
+        """
+        Lấy danh sách phiên bị dừng (status = 'running').
+        
+        Returns:
+            list[dict]: Danh sách phiên chưa hoàn thành
+        """
+        with self._get_connection() as conn:
+            rows = conn.execute("""
+                SELECT * FROM sessions 
+                WHERE status = 'running'
+                ORDER BY id DESC
+            """).fetchall()
+            return [dict(row) for row in rows]
+
+    def get_last_trade(self, session_id: int) -> Optional[dict[str, Any]]:
+        """
+        Lấy giao dịch cuối cùng của một phiên.
+        
+        Args:
+            session_id (int): ID phiên giao dịch
+        
+        Returns:
+            dict: Thông tin giao dịch cuối cùng hoặc None
+        """
+        with self._get_connection() as conn:
+            row = conn.execute("""
+                SELECT * FROM trades 
+                WHERE session_id = ?
+                ORDER BY id DESC
+                LIMIT 1
+            """, (session_id,)).fetchone()
+            return dict(row) if row else None
+
+    def get_last_trade_number(self, session_id: int) -> int:
+        """
+        Lấy số thứ tự giao dịch cuối cùng của một phiên.
+        
+        Args:
+            session_id (int): ID phiên giao dịch
+        
+        Returns:
+            int: Số thứ tự giao dịch cuối cùng (hoặc 0 nếu không có giao dịch)
+        """
+        with self._get_connection() as conn:
+            row = conn.execute("""
+                SELECT MAX(trade_number) as last_trade_number FROM trades 
+                WHERE session_id = ?
+            """, (session_id,)).fetchone()
+            return row['last_trade_number'] if row and row['last_trade_number'] else 0
+
+    def get_cumulative_profit_at_session(self, session_id: int) -> tuple[float, float]:
+        """
+        Lấy lợi nhuận tích lũy tại cuối phiên.
+        
+        Args:
+            session_id (int): ID phiên giao dịch
+        
+        Returns:
+            tuple: (cumulative_profit_pct, cumulative_profit_usd)
+        """
+        last_trade = self.get_last_trade(session_id)
+        if last_trade:
+            return (
+                last_trade.get('cumulative_profit_pct', 0),
+                last_trade.get('cumulative_profit_usd', 0)
+            )
+        return (0, 0)
+
+    def mark_session_interrupted(self, session_id: int, error_message: str = None) -> None:
+        """
+        Đánh dấu phiên là bị interrupt (chuẩn bị khôi phục).
+        
+        Args:
+            session_id (int): ID phiên giao dịch
+            error_message (str, optional): Thông báo lỗi
+        """
+        self.update_session(
+            session_id,
+            status='interrupted',
+            error_message=error_message or 'Session was interrupted and recovered'
+        )
+        log_info(f"Phiên #{session_id} được đánh dấu là interrupted")
+
+    def mark_session_resumed(self, session_id: int, new_session_id: int = None) -> None:
+        """
+        Đánh dấu phiên đã được khôi phục.
+        
+        Args:
+            session_id (int): ID phiên giao dịch cũ
+            new_session_id (int, optional): ID phiên mới sau khi khôi phục
+        """
+        if new_session_id:
+            # Liên kết phiên cũ với phiên mới (nếu có cột parent_session_id)
+            # Hiện tại ta chỉ cập nhật status
+            pass
+        
+        self.update_session(
+            session_id,
+            status='resumed'
+        )
+        log_info(f"Phiên #{session_id} được đánh dấu là resumed")
+
+    def get_session_recovery_info(self, session_id: int) -> dict[str, Any]:
+        """
+        Lấy thông tin đầy đủ để khôi phục phiên.
+        
+        Args:
+            session_id (int): ID phiên giao dịch
+        
+        Returns:
+            dict: Thông tin khôi phục
+        """
+        session = self.get_session(session_id)
+        if not session:
+            return None
+        
+        last_trade = self.get_last_trade(session_id)
+        last_trade_number = self.get_last_trade_number(session_id)
+        cum_profit_pct, cum_profit_usd = self.get_cumulative_profit_at_session(session_id)
+        balance_snapshots = self.get_balance_history(session_id)
+        opportunities_count = len(self.get_opportunities_by_session(session_id))
+        
+        return {
+            'session_id': session_id,
+            'mode': session.get('mode'),
+            'symbol': session.get('symbol'),
+            'exchanges': session.get('exchanges', '').split(','),
+            'usdt_amount': session.get('usdt_amount'),
+            'renew_time_minutes': session.get('renew_time_minutes'),
+            'start_time': session.get('start_time'),
+            'last_trade_number': last_trade_number,
+            'last_trade': dict(last_trade) if last_trade else None,
+            'cumulative_profit_pct': cum_profit_pct,
+            'cumulative_profit_usd': cum_profit_usd,
+            'balance_snapshots': balance_snapshots,
+            'opportunities_found': opportunities_count,
+            'trades_executed': session.get('trades_executed', 0)
+        }

--- a/services/exchange_service.py
+++ b/services/exchange_service.py
@@ -13,10 +13,37 @@ from utils.exceptions import ExchangeError, InsufficientBalanceError, FuturesErr
 from utils.helpers import calculate_average, extract_base_asset
 from services.rate_limiter import get_rate_limiter
 from configs import SUPPORTED_EXCHANGES
+import time
 
 # Tải biến môi trường
 load_dotenv()
 
+async def retry_with_backoff(func, *args, retries=3, backoff_in_seconds=1, **kwargs):
+    """
+    Thực hiện retry với backoff khi gọi hàm.
+
+    Args:
+        func (callable): Hàm cần gọi.
+        retries (int): Số lần thử lại tối đa.
+        backoff_in_seconds (int): Thời gian chờ ban đầu giữa các lần thử lại.
+        *args: Tham số truyền vào hàm.
+        **kwargs: Tham số keyword truyền vào hàm.
+
+    Returns:
+        Any: Kết quả trả về từ hàm.
+
+    Raises:
+        Exception: Nếu hết số lần thử lại mà vẫn thất bại.
+    """
+    for attempt in range(retries):
+        try:
+            return await func(*args, **kwargs)
+        except Exception as e:
+            log_error(f"Lỗi khi gọi hàm {func.__name__}: {str(e)}. Thử lại ({attempt + 1}/{retries})...")
+            if attempt < retries - 1:
+                await asyncio.sleep(backoff_in_seconds * (2 ** attempt))
+            else:
+                raise
 
 class ExchangeService:
     """
@@ -27,41 +54,70 @@ class ExchangeService:
         """Khởi tạo dịch vụ sàn giao dịch."""
         self.exchanges = {}
         self.exchange_instances = {}
+        self._use_sandbox = os.getenv('USE_SANDBOX', 'false').lower() == 'true'
         self._rate_limiter = get_rate_limiter()
         self._initialize_exchanges()
+
+    def _apply_sandbox_mode(self, exchange: Any, exchange_id: str) -> None:
+        """Bật sandbox mode nếu cấu hình môi trường yêu cầu."""
+        if not self._use_sandbox:
+            return
+
+        if hasattr(exchange, 'set_sandbox_mode'):
+            exchange.set_sandbox_mode(True)
+            log_info(f"Đã bật sandbox mode cho {exchange_id}")
+
+    def _get_env_value(self, prod_key: str, testnet_key: str) -> Optional[str]:
+        """Lấy giá trị env, ưu tiên key testnet khi bật sandbox."""
+        if self._use_sandbox:
+            testnet_value = os.getenv(testnet_key)
+            if testnet_value:
+                return testnet_value
+        return os.getenv(prod_key)
     
     def _initialize_exchanges(self) -> None:
         """Khởi tạo đối tượng sàn giao dịch với thông tin xác thực từ biến môi trường."""
         for exchange_id in SUPPORTED_EXCHANGES:
             self.exchanges[exchange_id] = {'enableRateLimit': True}
 
+        binance_api_key = self._get_env_value('BINANCE_API_KEY', 'BINANCE_TESTNET_API_KEY')
+        binance_secret = self._get_env_value('BINANCE_SECRET', 'BINANCE_TESTNET_SECRET')
+        kucoin_api_key = self._get_env_value('KUCOIN_API_KEY', 'KUCOIN_TESTNET_API_KEY')
+        kucoin_secret = self._get_env_value('KUCOIN_SECRET', 'KUCOIN_TESTNET_SECRET')
+        kucoin_password = self._get_env_value('KUCOIN_PASSWORD', 'KUCOIN_TESTNET_PASSWORD')
+        bybit_api_key = self._get_env_value('BYBIT_API_KEY', 'BYBIT_TESTNET_API_KEY')
+        bybit_secret = self._get_env_value('BYBIT_SECRET', 'BYBIT_TESTNET_SECRET')
+        okx_api_key = self._get_env_value('OKX_API_KEY', 'OKX_TESTNET_API_KEY')
+        okx_secret = self._get_env_value('OKX_SECRET', 'OKX_TESTNET_SECRET')
+        okx_password = self._get_env_value('OKX_PASSWORD', 'OKX_TESTNET_PASSWORD')
+
         # Khởi tạo Binance
-        if os.getenv('BINANCE_API_KEY') and os.getenv('BINANCE_SECRET'):
+        if binance_api_key and binance_secret:
             self.exchanges['binance'] = {
-                'apiKey': os.getenv('BINANCE_API_KEY'),
-                'secret': os.getenv('BINANCE_SECRET'),
+                'apiKey': binance_api_key,
+                'secret': binance_secret,
                 'options': {'createMarketBuyOrderRequiresPrice': False}
             }
         
         # Khởi tạo KuCoin
-        if os.getenv('KUCOIN_API_KEY') and os.getenv('KUCOIN_SECRET') and os.getenv('KUCOIN_PASSWORD'):
+        if kucoin_api_key and kucoin_secret and kucoin_password:
             self.exchanges['kucoin'] = {
-                'apiKey': os.getenv('KUCOIN_API_KEY'),
-                'secret': os.getenv('KUCOIN_SECRET'),
-                'password': os.getenv('KUCOIN_PASSWORD'),
+                'apiKey': kucoin_api_key,
+                'secret': kucoin_secret,
+                'password': kucoin_password,
                 'options': {'createMarketBuyOrderRequiresPrice': False}
             }
             self.exchanges['kucoinfutures'] = {
-                'apiKey': os.getenv('KUCOIN_API_KEY'),
-                'secret': os.getenv('KUCOIN_SECRET'),
-                'password': os.getenv('KUCOIN_PASSWORD')
+                'apiKey': kucoin_api_key,
+                'secret': kucoin_secret,
+                'password': kucoin_password
             }
         
         # Khởi tạo Bybit
-        if os.getenv('BYBIT_API_KEY') and os.getenv('BYBIT_SECRET'):
+        if bybit_api_key and bybit_secret:
             self.exchanges['bybit'] = {
-                'apiKey': os.getenv('BYBIT_API_KEY'),
-                'secret': os.getenv('BYBIT_SECRET'),
+                'apiKey': bybit_api_key,
+                'secret': bybit_secret,
                 'options': {
                     'defaultType': 'spot',
                     'createMarketBuyOrderRequiresPrice': False
@@ -69,11 +125,11 @@ class ExchangeService:
             }
         
         # Khởi tạo OKX
-        if os.getenv('OKX_API_KEY') and os.getenv('OKX_SECRET') and os.getenv('OKX_PASSWORD'):
+        if okx_api_key and okx_secret and okx_password:
             self.exchanges['okx'] = {
-                'apiKey': os.getenv('OKX_API_KEY'),
-                'secret': os.getenv('OKX_SECRET'),
-                'password': os.getenv('OKX_PASSWORD'),
+                'apiKey': okx_api_key,
+                'secret': okx_secret,
+                'password': okx_password,
                 'options': {'createMarketBuyOrderRequiresPrice': False}
             }
     
@@ -98,18 +154,20 @@ class ExchangeService:
                 # Tạo đối tượng sàn giao dịch
                 exchange_class = getattr(ccxt, exchange_id)
                 self.exchange_instances[exchange_id] = exchange_class(self.exchanges[exchange_id])
+                self._apply_sandbox_mode(self.exchange_instances[exchange_id], exchange_id)
                 log_info(f"Đã khởi tạo sàn giao dịch {exchange_id}")
             except Exception as e:
                 raise ExchangeError(exchange_id, f"Không thể khởi tạo sàn giao dịch: {str(e)}")
         
         return self.exchange_instances[exchange_id]
 
-    async def get_pro_exchange(self, exchange_id: str) -> Any:
+    async def get_pro_exchange(self, exchange_id: str, public_only: bool = False) -> Any:
         """
         Lấy đối tượng sàn giao dịch ccxt.pro theo id.
         
         Args:
             exchange_id (str): ID của sàn giao dịch
+            public_only (bool): Chỉ dùng endpoint public, không gửi credential
         
         Returns:
             object: Đối tượng sàn giao dịch ccxt.pro đã được khởi tạo
@@ -117,17 +175,12 @@ class ExchangeService:
         Raises:
             ExchangeError: Nếu sàn giao dịch không tồn tại hoặc không được hỗ trợ
         """
-        if exchange_id not in self.exchanges:
-            raise ExchangeError(exchange_id, "Sàn giao dịch không được hỗ trợ hoặc chưa được cấu hình")
-        
         try:
-            # Tạo đối tượng sàn giao dịch pro
-            exchange_class = getattr(ccxt.pro, exchange_id)
-            return exchange_class(self.exchanges[exchange_id])
+            return await self._get_or_create_pro_exchange(exchange_id, public_only=public_only)
         except Exception as e:
             raise ExchangeError(exchange_id, f"Không thể khởi tạo sàn giao dịch pro: {str(e)}")
     
-    def get_balance(self, exchange_id: str, symbol: str) -> dict[str, float]:
+    async def get_balance(self, exchange_id: str, symbol: str) -> dict[str, float]:
         """
         Lấy số dư của một tài sản trên sàn giao dịch.
         
@@ -142,38 +195,39 @@ class ExchangeService:
             ExchangeError: Nếu có lỗi khi lấy số dư
         """
         exchange = self.get_exchange(exchange_id)
-        
+
+        async def fetch():
+            return exchange.fetch_balance()
+
         try:
-            # Làm sạch symbol nếu nó có dạng BTC/USDT hoặc BTC:USDT
-            clean_symbol = extract_base_asset(symbol) if symbol != 'USDT' else 'USDT'
-            
-            balance = exchange.fetch_balance()
-            
-            if clean_symbol in balance['free'] and balance['free'][clean_symbol] != 0:
-                return balance['free'][clean_symbol]
-            return 0
+            return await retry_with_backoff(fetch)
         except Exception as e:
             raise ExchangeError(exchange_id, f"Không thể lấy số dư của {symbol}: {str(e)}")
     
-    def get_ticker(self, exchange_id: str, symbol: str) -> dict[str, Any]:
+    async def get_ticker(self, exchange_id: str, symbol: str) -> dict[str, Any]:
         """
-        Lấy thông tin ticker của một cặp giao dịch.
-        
+        Lấy thông tin ticker của một cặp giao dịch với retry.
+
         Args:
             exchange_id (str): ID của sàn giao dịch
             symbol (str): Ký hiệu của cặp giao dịch
-        
+
         Returns:
             dict: Thông tin ticker
-        
+
         Raises:
             ExchangeError: Nếu có lỗi khi lấy ticker
         """
         exchange = self.get_exchange(exchange_id)
-        
-        try:
+
+        async def fetch_ticker():
             return exchange.fetch_ticker(symbol)
+
+        try:
+            log_info(f"Đang gọi API get_ticker cho {exchange_id} với cặp {symbol}...")
+            return await retry_with_backoff(fetch_ticker)
         except Exception as e:
+            log_error(f"Lỗi khi gọi API get_ticker cho {exchange_id} với cặp {symbol}: {str(e)}")
             raise ExchangeError(exchange_id, f"Không thể lấy ticker cho {symbol}: {str(e)}")
     
     def create_limit_buy_order(self, exchange_id: str, symbol: str, amount: float,
@@ -194,8 +248,9 @@ class ExchangeService:
             ExchangeError: Nếu có lỗi khi tạo lệnh
         """
         exchange = self.get_exchange(exchange_id)
-        
+
         try:
+            self._rate_limiter.acquire(exchange_id)
             return exchange.create_limit_buy_order(symbol, amount, price)
         except Exception as e:
             raise ExchangeError(exchange_id, f"Không thể tạo lệnh mua giới hạn cho {symbol}: {str(e)}")
@@ -218,8 +273,9 @@ class ExchangeService:
             ExchangeError: Nếu có lỗi khi tạo lệnh
         """
         exchange = self.get_exchange(exchange_id)
-        
+
         try:
+            self._rate_limiter.acquire(exchange_id)
             return exchange.create_limit_sell_order(symbol, amount, price)
         except Exception as e:
             raise ExchangeError(exchange_id, f"Không thể tạo lệnh bán giới hạn cho {symbol}: {str(e)}")
@@ -243,8 +299,9 @@ class ExchangeService:
         """
         exchange = self.get_exchange(exchange_id)
         params = params or {}
-        
+
         try:
+            self._rate_limiter.acquire(exchange_id)
             return exchange.create_market_buy_order(symbol, amount, params)
         except Exception as e:
             raise ExchangeError(exchange_id, f"Không thể tạo lệnh mua thị trường cho {symbol}: {str(e)}")
@@ -268,8 +325,9 @@ class ExchangeService:
         """
         exchange = self.get_exchange(exchange_id)
         params = params or {}
-        
+
         try:
+            self._rate_limiter.acquire(exchange_id)
             return exchange.create_market_sell_order(symbol, amount, params)
         except Exception as e:
             raise ExchangeError(exchange_id, f"Không thể tạo lệnh bán thị trường cho {symbol}: {str(e)}")
@@ -414,7 +472,7 @@ class ExchangeService:
         
         try:
             for exchange_id in exchanges:
-                ticker = self.get_ticker(exchange_id, symbol)
+                ticker = await self.get_ticker(exchange_id, symbol)
                 all_tickers.append(ticker['bid'])
                 all_tickers.append(ticker['ask'])
             
@@ -559,26 +617,53 @@ class ExchangeService:
     # ─── Async Methods ────────────────────────────────────────────────
     # Các phương thức async sử dụng ccxt.pro cho đặt lệnh đồng thời
 
-    async def _get_or_create_pro_exchange(self, exchange_id: str) -> Any:
+    def _build_pro_exchange_config(self, exchange_id: str, public_only: bool = False) -> dict[str, Any]:
+        """
+        Tạo cấu hình cho ccxt.pro.
+
+        Args:
+            exchange_id (str): ID của sàn giao dịch
+            public_only (bool): Chỉ giữ lại cấu hình cần thiết cho endpoint public
+
+        Returns:
+            dict: Cấu hình dùng để khởi tạo client ccxt.pro
+        """
+        config = dict(self.exchanges[exchange_id])
+        if not public_only:
+            return config
+
+        public_config = {
+            'enableRateLimit': config.get('enableRateLimit', True)
+        }
+        if 'options' in config:
+            public_config['options'] = dict(config['options'])
+        return public_config
+
+    async def _get_or_create_pro_exchange(self, exchange_id: str, public_only: bool = False) -> Any:
         """
         Lấy hoặc tạo đối tượng sàn giao dịch ccxt.pro dùng lại được.
         
         Args:
             exchange_id (str): ID của sàn giao dịch
+            public_only (bool): Chỉ dùng endpoint public, không gửi credential
         
         Returns:
             object: Đối tượng sàn giao dịch ccxt.pro
         """
         if not hasattr(self, '_pro_instances'):
             self._pro_instances = {}
+
+        instance_key = f"{exchange_id}:public" if public_only else exchange_id
         
-        if exchange_id not in self._pro_instances:
+        if instance_key not in self._pro_instances:
             if exchange_id not in self.exchanges:
                 raise ExchangeError(exchange_id, "Sàn giao dịch không được hỗ trợ hoặc chưa được cấu hình")
             exchange_class = getattr(ccxt.pro, exchange_id)
-            self._pro_instances[exchange_id] = exchange_class(self.exchanges[exchange_id])
+            exchange_config = self._build_pro_exchange_config(exchange_id, public_only=public_only)
+            self._pro_instances[instance_key] = exchange_class(exchange_config)
+            self._apply_sandbox_mode(self._pro_instances[instance_key], exchange_id)
         
-        return self._pro_instances[exchange_id]
+        return self._pro_instances[instance_key]
 
     async def close_all_pro_exchanges(self):
         """Đóng tất cả kết nối ccxt.pro."""

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -43,15 +43,13 @@ class TestOrderServiceTimeout:
     """Test that the timeout calculation is correct."""
 
     def test_timeout_is_in_seconds(self):
-        """Regression test: FIRST_ORDERS_FILL_TIMEOUT is in seconds, not multiplied by 60."""
+        """Regression test: FIRST_ORDERS_FILL_TIMEOUT là giây, không phải phút."""
         from configs import FIRST_ORDERS_FILL_TIMEOUT
 
-        # The timeout should be 3600 seconds = 1 hour (not 3600 * 60 * 0.5 = 30 hours)
         timeout_seconds = FIRST_ORDERS_FILL_TIMEOUT
-        assert timeout_seconds == 3600
-        # Previously the bug was: timeout_seconds = FIRST_ORDERS_FILL_TIMEOUT * 60 * 0.5
-        # Which would be 108000 seconds = 30 hours
-        assert timeout_seconds < 7200  # Should be at most 2 hours
+        assert timeout_seconds == 300
+        # Phải đủ ngắn cho arbitrage (tối đa 10 phút = 600 giây)
+        assert timeout_seconds < 600
 
 
 class TestBaseBotZeroDivision:

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -38,8 +38,8 @@ class TestConfigs:
         assert "delta-neutral" in BOT_MODES
 
     def test_first_orders_fill_timeout_is_seconds(self):
-        # FIRST_ORDERS_FILL_TIMEOUT should be in seconds (3600 = 1 hour)
-        assert FIRST_ORDERS_FILL_TIMEOUT == 3600
+        # FIRST_ORDERS_FILL_TIMEOUT should be in seconds (300 = 5 phút — đủ cho arbitrage)
+        assert FIRST_ORDERS_FILL_TIMEOUT == 300
 
     def test_file_paths(self):
         assert BALANCE_FILE == "balance.txt"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -137,19 +137,21 @@ def notification_service():
 class TestBalanceServiceIntegration:
     """Test tích hợp giữa BalanceService và ExchangeService."""
 
-    def test_check_balances_sufficient(self, balance_service, mock_exchange_service):
+    @pytest.mark.asyncio
+    async def test_check_balances_sufficient(self, balance_service, mock_exchange_service):
         """Test khi có đủ số dư trên tất cả sàn."""
-        mock_exchange_service.get_balance.return_value = 500.0
-        result = balance_service.check_balances(
+        mock_exchange_service.async_get_balance.return_value = 500.0
+        result = await balance_service.check_balances(
             ['binance', 'kucoin', 'okx'], 'USDT', 1000.0
         )
         assert result is True
 
-    def test_check_balances_insufficient(self, balance_service, mock_exchange_service):
+    @pytest.mark.asyncio
+    async def test_check_balances_insufficient(self, balance_service, mock_exchange_service):
         """Test khi không đủ số dư."""
-        mock_exchange_service.get_balance.return_value = 50.0
+        mock_exchange_service.async_get_balance.return_value = 50.0
         with pytest.raises(InsufficientBalanceError):
-            balance_service.check_balances(
+            await balance_service.check_balances(
                 ['binance', 'kucoin', 'okx'], 'USDT', 1000.0
             )
 
@@ -171,13 +173,14 @@ class TestBalanceServiceIntegration:
         assert crypto['binance'] == pytest.approx(0.005)  # (1000/2) / 50000 / 2
         assert crypto['kucoin'] == pytest.approx(0.005)
 
-    def test_balance_caching(self, balance_service, mock_exchange_service):
+    @pytest.mark.asyncio
+    async def test_balance_caching(self, balance_service, mock_exchange_service):
         """Test rằng caching hoạt động."""
-        mock_exchange_service.get_balance.return_value = 500.0
-        balance_service.get_balance('binance', 'USDT')
-        balance_service.get_balance('binance', 'USDT')
+        mock_exchange_service.async_get_balance.return_value = 500.0
+        await balance_service.get_balance('binance', 'USDT')
+        await balance_service.get_balance('binance', 'USDT')
         # API chỉ gọi 1 lần nhờ cache
-        assert mock_exchange_service.get_balance.call_count == 1
+        assert mock_exchange_service.async_get_balance.call_count == 1
 
     def test_balance_file_operations(self, balance_service):
         """Test đọc/ghi file số dư."""

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -2,11 +2,38 @@
 Module quản lý ghi log của ứng dụng.
 """
 import os
+import sys
 import logging
 from datetime import datetime
 from typing import Any, Optional
 from colorama import Fore, Style
 from utils.helpers import show_time
+
+
+def configure_console_encoding() -> None:
+    """Cấu hình UTF-8 cho console khi môi trường hỗ trợ."""
+    for stream_name in ('stdin', 'stdout', 'stderr'):
+        stream = getattr(sys, stream_name, None)
+        if hasattr(stream, 'reconfigure'):
+            try:
+                stream.reconfigure(encoding='utf-8', errors='replace')
+            except (AttributeError, OSError, ValueError):
+                continue
+
+
+def safe_print(message: str) -> None:
+    """In ra console mà không làm crash khi terminal không hỗ trợ Unicode đầy đủ."""
+    stream = sys.stdout
+    try:
+        print(message)
+    except UnicodeEncodeError:
+        encoding = getattr(stream, 'encoding', None) or 'utf-8'
+        sanitized = message.encode(encoding, errors='replace').decode(encoding, errors='replace')
+        stream.write(sanitized + '\n')
+        stream.flush()
+
+
+configure_console_encoding()
 
 # Tạo thư mục logs nếu chưa tồn tại
 os.makedirs('logs', exist_ok=True)
@@ -18,17 +45,19 @@ log_file = f'logs/arbitrage_bot_{today}.log'
 # Tạo logger
 logger = logging.getLogger('arbitrage_bot')
 logger.setLevel(logging.DEBUG)
+logger.propagate = False
 
 # Tạo file handler để lưu log vào tệp tin
-file_handler = logging.FileHandler(log_file, encoding='utf-8')
-file_handler.setLevel(logging.DEBUG)
+if not logger.handlers:
+    file_handler = logging.FileHandler(log_file, encoding='utf-8')
+    file_handler.setLevel(logging.DEBUG)
 
-# Định dạng log
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-file_handler.setFormatter(formatter)
+    # Định dạng log
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    file_handler.setFormatter(formatter)
 
-# Thêm handler vào logger
-logger.addHandler(file_handler)
+    # Thêm handler vào logger
+    logger.addHandler(file_handler)
 
 
 def log_and_print(message: str, level: str = 'info', print_to_console: bool = True, telegram: Any = None) -> None:
@@ -47,7 +76,7 @@ def log_and_print(message: str, level: str = 'info', print_to_console: bool = Tr
     # Hiển thị ra màn hình nếu được yêu cầu
     if print_to_console:
         console_message = f"{Style.DIM}[{show_time()}]{Style.RESET_ALL} {message}"
-        print(console_message)
+        safe_print(console_message)
     
     # Gửi thông báo qua Telegram nếu có
     if telegram:

--- a/utils/session_recovery.py
+++ b/utils/session_recovery.py
@@ -1,0 +1,167 @@
+"""
+Công cụ khôi phục phiên giao dịch.
+Xử lý phát hiện, hỏi người dùng, và khôi phục phiên bị dừng.
+"""
+import time
+from typing import Optional, Any
+from datetime import datetime, timezone
+from colorama import Fore, Style
+
+from utils.logger import log_info, log_warning, log_error, safe_print
+from services.database_service import DatabaseService
+
+
+class SessionRecovery:
+    """
+    Lớp quản lý khôi phục phiên giao dịch bị dừng.
+    """
+    
+    def __init__(self, db_service: DatabaseService) -> None:
+        """
+        Khởi tạo công cụ khôi phục.
+        
+        Args:
+            db_service (DatabaseService): Dịch vụ database
+        """
+        self.db = db_service
+    
+    def get_interrupted_sessions(self) -> list[dict[str, Any]]:
+        """
+        Lấy danh sách phiên bị dừng.
+        
+        Returns:
+            list[dict]: Danh sách phiên
+        """
+        return self.db.get_interrupted_sessions()
+    
+    def show_interrupted_sessions(self) -> Optional[int]:
+        """
+        Hiển thị danh sách phiên bị dừng và hỏi người dùng có muốn khôi phục không.
+        
+        Returns:
+            int: ID phiên được chọn, hoặc None nếu người dùng không muốn khôi phục
+        """
+        interrupted_sessions = self.get_interrupted_sessions()
+        
+        if not interrupted_sessions:
+            log_info("Không có phiên nào bị dừng")
+            return None
+        
+        safe_print("\n" + "="*80)
+        safe_print(f"{Fore.YELLOW}Phát hiện {len(interrupted_sessions)} phiên bị dừng:{Style.RESET_ALL}")
+        safe_print("="*80)
+        
+        for idx, session in enumerate(interrupted_sessions, 1):
+            session_id = session['id']
+            mode = session['mode']
+            symbol = session['symbol']
+            exchanges = session['exchanges']
+            start_time = session['start_time']
+            usdt_amount = session['usdt_amount']
+            trades_executed = session['trades_executed']
+            profit_pct = session['total_profit_pct'] if session['total_profit_pct'] else 0
+            profit_usd = session['total_profit_usd'] if session['total_profit_usd'] else 0
+            
+            safe_print(f"\n[{idx}] Phiên #{session_id}:")
+            safe_print(f"    Chế độ: {mode}")
+            safe_print(f"    Cặp tiền: {symbol}")
+            safe_print(f"    Sàn: {exchanges}")
+            safe_print(f"    Vốn: {usdt_amount} USDT")
+            safe_print(f"    Thời gian bắt đầu: {start_time}")
+            safe_print(f"    Giao dịch đã thực hiện: {trades_executed}")
+            safe_print(f"    Lợi nhuận: {profit_pct:.4f}% ({profit_usd:.4f} USDT)")
+        
+        safe_print("\n" + "="*80)
+        safe_print(f"{Fore.CYAN}Tùy chọn:{Style.RESET_ALL}")
+        safe_print(f"  [1-{len(interrupted_sessions)}] - Khôi phục phiên")
+        safe_print(f"  [0 hoặc Enter] - Chạy phiên mới")
+        
+        while True:
+            try:
+                choice = input(f"\n{Fore.CYAN}Lựa chọn của bạn:{Style.RESET_ALL} ").strip()
+                
+                if choice == '' or choice == '0':
+                    log_info("Bắt đầu phiên mới (không khôi phục)")
+                    return None
+                
+                choice_idx = int(choice) - 1
+                if 0 <= choice_idx < len(interrupted_sessions):
+                    selected_session = interrupted_sessions[choice_idx]
+                    log_info(f"Khôi phục phiên #{selected_session['id']}")
+                    return selected_session['id']
+                else:
+                    safe_print(f"{Fore.RED}Lựa chọn không hợp lệ. Vui lòng thử lại.{Style.RESET_ALL}")
+                    
+            except ValueError:
+                safe_print(f"{Fore.RED}Vui lòng nhập số hợp lệ.{Style.RESET_ALL}")
+            except KeyboardInterrupt:
+                safe_print('')
+                log_info("Hủy khôi phục. Chạy phiên mới.")
+                return None
+    
+    def get_recovery_info(self, session_id: int) -> Optional[dict[str, Any]]:
+        """
+        Lấy thông tin để khôi phục phiên.
+        
+        Args:
+            session_id (int): ID phiên cần khôi phục
+        
+        Returns:
+            dict: Thông tin khôi phục
+        """
+        recovery_info = self.db.get_session_recovery_info(session_id)
+        
+        if recovery_info:
+            safe_print(f"\n{Fore.CYAN}Thông tin khôi phục:{Style.RESET_ALL}")
+            safe_print(f"  Phiên ID: {recovery_info['session_id']}")
+            safe_print(f"  Chế độ: {recovery_info['mode']}")
+            safe_print(f"  Cặp tiền: {recovery_info['symbol']}")
+            safe_print(f"  Sàn: {', '.join(recovery_info['exchanges'])}")
+            safe_print(f"  Vốn: {recovery_info['usdt_amount']} USDT")
+            safe_print(f"  Giao dịch đã thực hiện: {recovery_info['trades_executed']}")
+            safe_print(f"  Lợi nhuận tích lũy: {recovery_info['cumulative_profit_pct']:.4f}%")
+            safe_print(f"  Thời gian bắt đầu: {recovery_info['start_time']}")
+        
+        return recovery_info
+    
+    def mark_interrupted(self, session_id: int, error_message: str = None) -> None:
+        """
+        Đánh dấu phiên là bị interrupt.
+        
+        Args:
+            session_id (int): ID phiên
+            error_message (str, optional): Thông báo lỗi
+        """
+        self.db.mark_session_interrupted(session_id, error_message)
+    
+    def mark_resumed(self, session_id: int) -> None:
+        """
+        Đánh dấu phiên đã được khôi phục.
+        
+        Args:
+            session_id (int): ID phiên
+        """
+        self.db.mark_session_resumed(session_id)
+    
+    @staticmethod
+    def extract_recovery_params(recovery_info: dict[str, Any]) -> dict[str, Any]:
+        """
+        Trích xuất các tham số để chạy bot từ thông tin khôi phục.
+        
+        Args:
+            recovery_info (dict): Thông tin khôi phục
+        
+        Returns:
+            dict: Tham số cho bot
+        """
+        return {
+            'mode': recovery_info['mode'],
+            'symbol': recovery_info['symbol'],
+            'usdt_amount': recovery_info['usdt_amount'],
+            'renew_time': recovery_info['renew_time_minutes'],
+            'exchanges': recovery_info['exchanges'],
+            'recovered_session_id': recovery_info['session_id'],
+            'last_trade_number': recovery_info['last_trade_number'],
+            'cumulative_profit_pct': recovery_info['cumulative_profit_pct'],
+            'cumulative_profit_usd': recovery_info['cumulative_profit_usd']
+        }


### PR DESCRIPTION
- configs: tăng PROFIT_CRITERIA_PCT=0.05%, PROFIT_CRITERIA_USD=$0.5 (trước là 0 — bot giao dịch lỗ)
- configs: giảm FIRST_ORDERS_FILL_TIMEOUT 3600→300s (5 phút đủ cho arbitrage)
- base_bot: guard orderbook rỗng tránh IndexError khi sàn bảo trì
- base_bot: guard crypto_per_transaction<=0 tránh đặt lệnh amount=0
- async_order_service: xử lý partial fill race condition — khi buy/sell lệch, tự động hủy hoặc đảo lệnh khẩn cấp thay vì để vị thế không cân bằng
- exchange_service: thêm rate_limiter.acquire() vào 4 sync order methods còn thiếu
- Thêm CLAUDE.md, session recovery, examples, docs